### PR TITLE
Fix technic item becoming unknown nodes

### DIFF
--- a/mods/wrench/depends.txt
+++ b/mods/wrench/depends.txt
@@ -1,1 +1,2 @@
 default
+technic?


### PR DESCRIPTION
The reason is because the technic node wasn't define when this mod ran and register the wrench nodes
Fixes #26